### PR TITLE
Update to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,12 +49,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,26 +90,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -126,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -297,12 +289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,16 +308,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "inout"
@@ -570,12 +546,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4.0.0", features = ["derive"] }
 byteorder = "1.4.3"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 aes-gcm = "0.10.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,72 +26,74 @@ use errors::TeleportError;
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 pub enum Cmd {
+    /// Start a teleporter in server (receiving) mode
     Listen(ListenOpt),
+    /// Start a teleporter in client (sending) mode
     Send(SendOpt),
 }
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 pub struct Opt {
     /// Command
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Cmd,
 }
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 pub struct SendOpt {
     /// List of filepaths to files that will be teleported
-    #[clap(short, long, multiple_values = true, default_value = "")]
+    #[arg(short, long, num_args = ..)]
     input: Vec<PathBuf>,
 
     /// Destination teleporter IP address
-    #[clap(short, long, default_value = "127.0.0.1")]
-    dest: String,
+    #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST)]
+    dest: Ipv4Addr,
 
     /// Destination teleporter Port
-    #[clap(short, long, default_value = "9001")]
+    #[arg(short, long, default_value = "9001")]
     port: u16,
 
     /// Overwrite remote file
-    #[clap(short, long)]
+    #[arg(short, long)]
     overwrite: bool,
 
     /// Recurse into directories on send
-    #[clap(short, long)]
+    #[arg(short, long)]
     recursive: bool,
 
     /// Encrypt the file transfer using ECDH key-exchange and random keys
-    #[clap(short, long)]
+    #[arg(short, long)]
     encrypt: bool,
 
     /// Disable delta transfer (overwrite will transfer entire file)
-    #[clap(short, long)]
+    #[arg(short, long)]
     no_delta: bool,
 
     /// Keep path info (recreate directory path on remote server)
-    #[clap(short, long)]
+    #[arg(short, long)]
     keep_path: bool,
 
     /// Backup the destination file to a ".bak" extension if it exists and is being overwritten (consecutive runs will replace the *.bak file)
-    #[clap(short, long)]
+    #[arg(short, long)]
     backup: bool,
 
     /// If the destination file exists, append a ".1" (or next available number) to the filename instead of overwriting
-    #[clap(short, long)]
+    #[arg(short, long)]
     filename_append: bool,
 }
 
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 pub struct ListenOpt {
     /// Allow absolute and relative file paths for transfers (server only) [WARNING: potentially dangerous option, use at your own risk!]
-    #[clap(long)]
+    #[arg(long)]
     allow_dangerous_filepath: bool,
 
     /// Require encryption for incoming connections to the server
-    #[clap(short, long)]
+    #[arg(short, long)]
     must_encrypt: bool,
 
     /// Port to listen on
-    #[clap(short, long, default_value = "9001")]
+    #[arg(short, long, default_value = "9001")]
     port: u16,
 }
 


### PR DESCRIPTION
* Use Ipv4 as the type for dest
* default_value = "" was changed to num_args
* Added help text for actions

```
Teleporter is a simple application for sending files from Point A to Point B

Usage: teleporter <COMMAND>

Commands:
  listen  Start a teleporter in server (receiving) mode
  send    Start a teleporter in client (sending) mode
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help information
```

```
Start a teleporter in client (sending) mode

Usage: teleporter send [OPTIONS]

Options:
  -i, --input [<INPUT>...]  List of filepaths to files that will be teleported
  -d, --dest <DEST>         Destination teleporter IP address [default: 127.0.0.1]
  -p, --port <PORT>         Destination teleporter Port [default: 9001]
  -o, --overwrite           Overwrite remote file
  -r, --recursive           Recurse into directories on send
  -e, --encrypt             Encrypt the file transfer using ECDH key-exchange and random keys
  -n, --no-delta            Disable delta transfer (overwrite will transfer entire file)
  -k, --keep-path           Keep path info (recreate directory path on remote server)
  -b, --backup              Backup the destination file to a ".bak" extension if it exists and is being overwritten (consecutive runs will replace the *.bak file)
  -f, --filename-append     If the destination file exists, append a ".1" (or next available number) to the filename instead of overwriting
  -h, --help                Print help information
```

```
Start a teleporter in server (receiving) mode

Usage: teleporter listen [OPTIONS]

Options:
      --allow-dangerous-filepath  Allow absolute and relative file paths for transfers (server only) [WARNING: potentially dangerous option, use at your own risk!]
  -m, --must-encrypt              Require encryption for incoming connections to the server
  -p, --port <PORT>               Port to listen on [default: 9001]
  -h, --help                      Print help information
```