### PR TITLE
Update CI, add MSRV, add static musl build

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,105 +10,73 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linux-fmt:
-    name: Rustfmt
+  # fmt and clippy
+  fmt-clippy:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
 
-  linux-check:
-    name: Build
-    needs: linux-fmt
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      # fmt
+      - run: cargo fmt --all -- --check
+
+      # clippy
+      - run: cargo clippy -- -D warnings
+
+  # build, test all supported targets
+  build-test-stable:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        targets:
+          - x86_64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+        toolchain:
+          # msrv
+          - 1.64.0
+          - stable
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.targets }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cross --git https://github.com/cross-rs/cross
+      - run: cross build --locked --workspace --target ${{ matrix.targets }}
+      - run: cross build --locked --workspace --target ${{ matrix.targets }} --release
+      - run: cross test --locked --workspace --target ${{ matrix.targets }}
+      - uses: actions/upload-artifact@v3
         with:
-          command: build
+          name: teleporter-${{ matrix.targets }}
+          path: target/${{ matrix.targets }}/release/teleporter
 
-  linux-test:
-    name: Linux Test Suite
-    needs: linux-check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  linux-release:
-    name: Release Linux x86_64
-    needs: linux-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-      - uses: actions/upload-artifact@v2.2.4
-        with:
-          name: teleporter-linux-x86_64
-          path: target/release/teleporter
-
-  macos-test:
-    name: MacOS Test Suite
-    needs: linux-check
+  build-test-macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        targets:
+          - x86_64-apple-darwin
+        toolchain:
+          # msrv
+          - 1.64.0
+          - stable
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.targets }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --locked --workspace --target ${{ matrix.targets }}
+      - run: cargo build --locked --workspace --target ${{ matrix.targets }} --release
+      - run: cargo test --locked --workspace --target ${{ matrix.targets }}
+      - uses: actions/upload-artifact@v3
         with:
-          command: test
-
-  macos-release:
-    name: Release Darwin x86_64
-    needs: macos-test
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: x86_64-apple-darwin 
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-      - uses: actions/upload-artifact@v2.2.4
-        with:
-          name: teleporter-darwin-x86_64
-          path: target/release/teleporter
+          name: teleporter-${{ matrix.targets }}
+          path: target/${{ matrix.targets }}/release/teleporter

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/genonullfree/teleporter.git"
 keywords = ["netcat", "teleport", "teleporter", "transfer", "send"]
 categories = ["command-line-utilities", "network-programming"]
 edition = "2021"
+rust-version = "1.64.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -45,7 +45,7 @@ pub fn run(opt: ListenOpt) -> Result<(), TeleportError> {
         let recv_list_clone = Arc::clone(&recv_list);
         thread::spawn(move || {
             if let Err(e) = handle_connection(s, &recv_list_clone, args) {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
             }
             let recv_list = recv_list_clone.lock().unwrap();
             print_list(&recv_list);
@@ -68,7 +68,7 @@ fn print_list(list: &MutexGuard<Vec<String>>) {
     if list.len() == 0 {
         print!("\rListening...");
     } else {
-        print!("\rReceiving: {:?}", list);
+        print!("\rReceiving: {list:?}");
     }
     io::stdout().flush().unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,6 @@ fn main() {
     // Display any errors
     match out {
         Ok(()) => {}
-        Err(s) => println!("Error: {}", s),
+        Err(s) => println!("Error: {s}"),
     };
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -21,7 +21,7 @@ fn get_file_list(opt: &SendOpt) -> Vec<String> {
             let mut tmp = match scope_dir(item) {
                 Ok(t) => t,
                 Err(_) => {
-                    println!("Error: Cannot read item: {:?}", item);
+                    println!("Error: Cannot read item: {item:?}");
                     continue;
                 }
             };
@@ -52,7 +52,7 @@ fn scope_dir(dir: &Path) -> Result<Vec<String>, Error> {
             let mut tmp = match scope_dir(&entry.as_ref().unwrap().path()) {
                 Ok(t) => t,
                 Err(_) => {
-                    println!("Error: Cannot read dir: {:?}", entry);
+                    println!("Error: Cannot read dir: {entry:?}");
                     continue;
                 }
             };
@@ -80,14 +80,14 @@ fn find_replacements(opt: &mut SendOpt) -> Replace {
     // Iterate over the input list
     for (idx, item) in opt.input.iter().enumerate() {
         // If it is a filename, no rename is happening
-        if File::open(&item).is_ok() {
+        if File::open(item).is_ok() {
             continue;
         }
 
         let path = item.to_str().unwrap();
 
         // If the path name contains ':'
-        if path.contains(&":") {
+        if path.contains(':') {
             // Split on ':' and use the first as original name
             // and the second as the new name
             let mut split = path.split(':');
@@ -120,7 +120,7 @@ fn find_replacements(opt: &mut SendOpt) -> Replace {
 
 /// Client function sends filename and file data for each filepath
 pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
-    print!("Teleporter Client {} => ", VERSION);
+    print!("Teleporter Client {VERSION} => ");
     let start_time = Instant::now();
     let mut sent = 0;
     let mut skip = 0;
@@ -154,15 +154,15 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         }
 
         // Validate file
-        let file = match File::open(&filepath) {
+        let file = match File::open(filepath) {
             Ok(f) => f,
             Err(s) => {
-                println!("Error opening file: {}", filepath);
+                println!("Error opening file: {filepath}");
                 return Err(TeleportError::Io(s));
             }
         };
 
-        let thread_file = File::open(&filepath)?;
+        let thread_file = File::open(filepath)?;
         // Skip if opt.no_delta present, otherwise calculate the delta hash of the file
         let handle = match opt.overwrite && !opt.no_delta {
             true => Some(thread::spawn(move || {
@@ -319,7 +319,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         // Print file transfer statistics
         let duration = file_time.elapsed();
         let speed = (header.filesize as f64 * 8.0) / duration.as_secs() as f64 / 1024.0 / 1024.0;
-        println!(" done! Time: {:.2?} Speed: {:.3} Mbps", duration, speed);
+        println!(" done! Time: {duration:.2?} Speed: {speed:.3} Mbps");
     }
     let total_time = start_time.elapsed();
     println!(

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -43,7 +43,7 @@ impl TeleportHeader {
         out.append(&mut self.data_len.to_le_bytes().to_vec());
 
         // Add action code
-        let mut action = self.action as u8;
+        let mut action = self.action;
         if self.iv.is_some() {
             action |= TeleportAction::Encrypted as u8;
         }
@@ -193,7 +193,7 @@ impl TeleportInit {
         }
 
         // Add features
-        out.append(&mut (self.features as u32).to_le_bytes().to_vec());
+        out.append(&mut self.features.to_le_bytes().to_vec());
 
         // Add chmod
         out.append(&mut self.chmod.to_le_bytes().to_vec());
@@ -206,7 +206,7 @@ impl TeleportInit {
         out.append(&mut flen.to_le_bytes().to_vec());
 
         // Add filename
-        out.append(&mut self.filename.iter().map(|x| *x as u8).collect());
+        out.append(&mut self.filename.to_vec());
 
         Ok(out)
     }
@@ -306,7 +306,7 @@ impl TeleportInitAck {
         let mut out = Vec::<u8>::new();
 
         // Add status
-        let status = self.status as u8;
+        let status = self.status;
         out.append(&mut vec![status]);
 
         // Add version
@@ -320,7 +320,7 @@ impl TeleportInitAck {
         }
 
         // Add optional features
-        let feat = self.features.unwrap() as u32;
+        let feat = self.features.unwrap();
         out.append(&mut feat.to_le_bytes().to_vec());
 
         // If no delta, return early


### PR DESCRIPTION
- Use dtolnay/rust-toolchain. actions-rs is unmaintained, remove all
  uses.
- Add rust-version (MSRV), found with `cargo msrv`.
- Test stable and MSRV in ci.
- Use matrix for targets, except for macos
- Add static build for x86_64-unknown-linux-musl
- Update actions/upload-artifact to v3