### PR TITLE
Remove unwraps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "teleporter"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes-gcm",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleporter"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["geno nullfree <nullfree.geno@gmail.com>"]
 license = "BSD-3-Clause"
 description = "A small utility to send files quickly from point A to point B"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::num::ParseIntError;
+use std::num::{ParseIntError, TryFromIntError};
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
@@ -18,6 +18,9 @@ pub enum TeleportError {
 
     #[error("Error in conversion of Int")]
     ParseIntError(#[from] ParseIntError),
+
+    #[error("Error trying to convert from Int")]
+    TryFromIntError(#[from] TryFromIntError),
 
     #[error("Error with destination address")]
     InvalidDest,

--- a/src/send.rs
+++ b/src/send.rs
@@ -277,7 +277,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         }
 
         // Validate response
-        match recv.status.try_into().unwrap() {
+        match recv.status.try_into()? {
             TeleportStatus::NoOverwrite => {
                 println!("The server refused to overwrite the file: {:?}", &filename);
                 continue;

--- a/src/send.rs
+++ b/src/send.rs
@@ -5,7 +5,7 @@ use crate::SendOpt;
 use crate::VERSION;
 use crate::{crypto, utils};
 use std::fs::File;
-use std::io::{Error, Read, Seek, SeekFrom};
+use std::io::{Read, Seek, SeekFrom};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -36,19 +36,23 @@ fn get_file_list(opt: &SendOpt) -> Vec<String> {
             files.append(&mut tmp);
         } else if item.exists() && item.is_file() {
             // Append the file
-            files.push(item.to_str().unwrap().to_string());
+            files.push(
+                item.to_str()
+                    .expect("Fatal error converting item to str")
+                    .to_string(),
+            );
         }
     }
 
     files
 }
 
-fn scope_dir(dir: &Path) -> Result<Vec<String>, Error> {
+fn scope_dir(dir: &Path) -> Result<Vec<String>, TeleportError> {
     let path = Path::new(&dir);
     let mut files = Vec::<String>::new();
 
     // Iterate over each item in directory
-    for entry in path.read_dir().unwrap() {
+    for entry in path.read_dir()? {
         if entry.as_ref().unwrap().file_type().unwrap().is_dir() {
             // Skip current directory
             if entry.as_ref().unwrap().path() == *dir {

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -43,7 +43,7 @@ impl TeleportHeader {
         out.append(&mut self.protocol.to_le_bytes().to_vec());
 
         // Add data length
-        self.data_len = u32::try_from(self.data.len()).unwrap();
+        self.data_len = u32::try_from(self.data.len())?;
         out.append(&mut self.data_len.to_le_bytes().to_vec());
 
         // Add action code
@@ -68,17 +68,17 @@ impl TeleportHeader {
         let mut buf: &[u8] = &input;
 
         // Extract Protocol
-        self.protocol = buf.read_u64::<LittleEndian>().unwrap();
+        self.protocol = buf.read_u64::<LittleEndian>()?;
         if self.protocol != PROTOCOL {
             return Err(TeleportError::InvalidHeaderRead);
         }
 
         // Extract data length
-        self.data_len = buf.read_u32::<LittleEndian>().unwrap();
+        self.data_len = buf.read_u32::<LittleEndian>()?;
         let mut data_ofs = 13;
 
         // Extract action code
-        let action = buf.read_u8().unwrap();
+        let action = buf.read_u8()?;
         self.action = action;
 
         // If Encrypted, extract IV
@@ -200,7 +200,7 @@ impl TeleportInit {
         out.append(&mut self.filesize.to_le_bytes().to_vec());
 
         // Add filename_len
-        let flen = u16::try_from(self.filename.len()).unwrap();
+        let flen = u16::try_from(self.filename.len())?;
         out.append(&mut flen.to_le_bytes().to_vec());
 
         // Add filename
@@ -214,20 +214,20 @@ impl TeleportInit {
 
         // Extract version info
         for i in &mut self.version {
-            *i = buf.read_u16::<LittleEndian>().unwrap();
+            *i = buf.read_u16::<LittleEndian>()?;
         }
 
         // Extract file command feature requests
-        self.features = buf.read_u32::<LittleEndian>().unwrap();
+        self.features = buf.read_u32::<LittleEndian>()?;
 
         // Extract file chmod permissions
-        self.chmod = buf.read_u32::<LittleEndian>().unwrap();
+        self.chmod = buf.read_u32::<LittleEndian>()?;
 
         // Extract file size
-        self.filesize = buf.read_u64::<LittleEndian>().unwrap();
+        self.filesize = buf.read_u64::<LittleEndian>()?;
 
         // Extract filename_len
-        self.filename_len = buf.read_u16::<LittleEndian>().unwrap();
+        self.filename_len = buf.read_u16::<LittleEndian>()?;
 
         // Extract filename
         let fname = &buf[..self.filename_len as usize].to_vec();
@@ -335,11 +335,11 @@ impl TeleportInitAck {
         let mut buf: &[u8] = input;
 
         // Extract status
-        self.status = buf.read_u8().unwrap();
+        self.status = buf.read_u8()?;
 
         // Extract version
         for i in &mut self.version {
-            *i = buf.read_u16::<LittleEndian>().unwrap();
+            *i = buf.read_u16::<LittleEndian>()?;
         }
 
         // If no features, return early
@@ -348,7 +348,7 @@ impl TeleportInitAck {
         }
 
         // Extract optional features
-        let features = buf.read_u32::<LittleEndian>().unwrap();
+        let features = buf.read_u32::<LittleEndian>()?;
         self.features = Some(features);
 
         // If no delta, return early
@@ -408,7 +408,7 @@ impl TeleportDelta {
         out.append(&mut self.chunk_size.to_le_bytes().to_vec());
 
         // Add delta vector length
-        let dlen = u16::try_from(self.chunk_hash.len()).unwrap();
+        let dlen = u16::try_from(self.chunk_hash.len())?;
         out.append(&mut dlen.to_le_bytes().to_vec());
 
         // Add delta vector
@@ -426,7 +426,7 @@ impl TeleportDelta {
         let mut buf = input;
         let mut count: u16 = len;
         while count > 0 {
-            let a: u64 = buf.read_u64::<LittleEndian>().unwrap();
+            let a: u64 = buf.read_u64::<LittleEndian>()?;
             out.push(a);
             count -= 1;
         }
@@ -441,19 +441,19 @@ impl TeleportDelta {
             return Err(TeleportError::InvalidLength);
         }
 
-        self.filesize = buf.read_u64::<LittleEndian>().unwrap();
+        self.filesize = buf.read_u64::<LittleEndian>()?;
 
         // Extract file hash
-        self.hash = buf.read_u64::<LittleEndian>().unwrap();
+        self.hash = buf.read_u64::<LittleEndian>()?;
 
         // Extract chunk size
-        self.chunk_size = buf.read_u32::<LittleEndian>().unwrap();
+        self.chunk_size = buf.read_u32::<LittleEndian>()?;
 
         // Extract delta vector length
-        self.chunk_hash_len = buf.read_u16::<LittleEndian>().unwrap();
+        self.chunk_hash_len = buf.read_u16::<LittleEndian>()?;
 
         // Extract delta vector
-        self.chunk_hash = TeleportDelta::delta_deserial(buf, self.chunk_hash_len).unwrap();
+        self.chunk_hash = TeleportDelta::delta_deserial(buf, self.chunk_hash_len)?;
 
         Ok(())
     }
@@ -482,7 +482,7 @@ impl TeleportData {
         out.append(&mut self.offset.to_le_bytes().to_vec());
 
         // Add data length
-        let length = u32::try_from(self.data.len()).unwrap();
+        let length = u32::try_from(self.data.len())?;
         out.append(&mut length.to_le_bytes().to_vec());
 
         // Add data
@@ -495,10 +495,10 @@ impl TeleportData {
         let mut buf: &[u8] = input;
 
         // Extract offset
-        self.offset = buf.read_u64::<LittleEndian>().unwrap();
+        self.offset = buf.read_u64::<LittleEndian>()?;
 
         // Extract data length
-        self.data_len = buf.read_u32::<LittleEndian>().unwrap();
+        self.data_len = buf.read_u32::<LittleEndian>()?;
 
         // Extract data
         self.data = input[12..].to_vec();


### PR DESCRIPTION
Closes #92 

This removes most of the unnecessary unwraps, utilizing either `?` error handling or explicitly calling `.expect()` with an error message.