### PR TITLE
Only append delta if feature is set

### DIFF
--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -324,11 +324,11 @@ impl TeleportInitAck {
             {
                 return Ok(out);
             }
-        }
 
-        // Add optional TeleportDelta data
-        if let Some(delta) = self.delta {
-            out.append(&mut delta.serialize()?);
+            // Add optional TeleportDelta data
+            if let Some(delta) = self.delta {
+                out.append(&mut delta.serialize()?);
+            }
         }
 
         Ok(out)


### PR DESCRIPTION
The current block appears to be checking if there are deltas and returning early if there are not, which is just extra work of what the next block would be doing