### PR TITLE
Scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "teleporter"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "aes-gcm",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +232,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +302,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +330,97 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "pnet"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd959a8268165518e2bf5546ba84c7b3222744435616381df3c456fe8d983576"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
+name = "pnet_base"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872e46346144ebf35219ccaa64b1dffacd9c6f188cd7d012bd6977a2a838f42e"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c302da22118d2793c312a35fb3da6846cb0fab6c3ad53fd67e37809b06cdafce"
+dependencies = [
+ "ipnetwork",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d932134f32efd7834eb8b16d42418dac87086347d1bc7d142370ef078582bc"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde678bbd85cb1c2d99dc9fc596e57f03aa725f84f3168b0eaf33eeccb41706"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf7a58b2803d818a374be9278a1fe8f88fce14b936afbe225000cfcd9c73f16"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813d1c0e4defbe7ee22f6fe1755f122b77bfb5abe77145b1b5baaf463cab9249"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
+]
 
 [[package]]
 name = "polyval"
@@ -406,6 +533,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "rustix"
 version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +568,12 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "strsim"
@@ -468,6 +618,9 @@ dependencies = [
  "byteorder",
  "clap",
  "generic-array",
+ "ipnetwork",
+ "pnet",
+ "pnet_datalink",
  "rand",
  "semver",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ x25519-dalek = "1.2"
 semver = "1.0"
 rand = "0.7"
 thiserror = "1.0"
+pnet = "0.33.0"
+pnet_datalink = "0.33.0"
+ipnetwork = "0.20.0"
 
 [profile.size]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teleporter"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["geno nullfree <nullfree.geno@gmail.com>"]
 license = "BSD-3-Clause"
 description = "A small utility to send files quickly from point A to point B"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ Options:
 
 Teleporter will transfer files with their name information as well as their file permissions. Any file path information will be lost unless the `-k` option is enabled. All the received files will be written out in the CWD where the server side was started unless the server was started with the `--allow-dangerous-filepath` option. When overwriting a file with the `-o` option, additional modifiers can be used, such as `-b` to make a backup of the original file, or `-n` to disable delta file transfers and always overwrite the entire file. 
 
+## Scan for Teleporter Instances
+
+To have teleporter scan the local network for any reachable teleporter instances, run:
+
+```
+teleporter scan
+```
+This will iterate through all the network devices (except the loopback device!) and will attempt to locate any teleporter servers listening on a specific port. It will report back if any server is found and what version they are running. This feature is only available on teleporter v0.10.7 and higher.
+
+Here are the additional arguments for scanning:
+```
+Scan all network devices for any reachable Teleport listeners
+
+Usage: teleporter scan [OPTIONS]
+
+Options:
+  -p, --port <PORT>  Port to scan for [default: 9001]
+  -h, --help         Print help
+```
+
 ## Rename / Copy-To
 
 Teleporter can now set remote file locations, or file renaming, via the `:` operator. Similar to how `Docker` allows quick mounting of directory locations, Teleporter will first attempt to open a file by the full given path, if that file does not exist, it will see if there are any colons (`:`) in the filename. If present, it will split the filepath and attempt to open on the first portion of the name. If that succeeds, Teleporter assumes this is a file rename / copy-to. Teleporter will also need the `-k` option, to keep filepath information. Otherwise only the file name will be changed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 pub mod errors;
 pub mod listen;
 pub mod send;
+pub mod scan;
 
 mod crypto;
 mod teleport;
@@ -66,6 +67,13 @@ pub struct ListenOpt {
     must_encrypt: bool,
 
     /// Port to listen on
+    #[arg(short, long, default_value = "9001")]
+    port: u16,
+}
+
+#[derive(Clone, Debug, Parser, PartialEq, Eq)]
+pub struct ScanOpt {
+    /// Port to scan for
     #[arg(short, long, default_value = "9001")]
     port: u16,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 pub mod errors;
 pub mod listen;
-pub mod send;
 pub mod scan;
+pub mod send;
 
 mod crypto;
 mod teleport;

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -106,14 +106,13 @@ fn handle_connection(
     let mut packet = utils::recv_packet(&mut stream, &None)?;
     if packet.action == TeleportAction::Ping as u8 {
         let mut ping = TeleportInit::default();
-        ping.deserialize(&mut packet.data)?;
+        ping.deserialize(&packet.data)?;
         if !TeleportFeatures::Ping.check_u32(ping.features) {
             return Ok(());
         }
         println!(
             "\rPing received from Teleporter v{} at {}",
-            ping.version.to_string(),
-            ip
+            ping.version, ip
         );
         let pong = TeleportInitAck::new(TeleportStatus::Pong);
         return utils::send_packet(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
-use teleporter::{listen, send, scan};
-use teleporter::{ListenOpt, SendOpt, ScanOpt};
+use teleporter::{listen, scan, send};
+use teleporter::{ListenOpt, ScanOpt, SendOpt};
 
 /// Teleporter is a simple application for sending files from Point A to Point B
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
-use teleporter::{listen, send};
-use teleporter::{ListenOpt, SendOpt};
+use teleporter::{listen, send, scan};
+use teleporter::{ListenOpt, SendOpt, ScanOpt};
 
 /// Teleporter is a simple application for sending files from Point A to Point B
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
@@ -18,6 +18,8 @@ pub enum Cmd {
     Listen(ListenOpt),
     /// Start a teleporter in client (sending) mode
     Send(SendOpt),
+    /// Scan all network devices for any reachable Teleport listeners
+    Scan(ScanOpt),
 }
 
 fn main() {
@@ -28,6 +30,7 @@ fn main() {
     let out = match opt.cmd {
         Cmd::Listen(l) => listen::run(l),
         Cmd::Send(s) => send::run(s),
+        Cmd::Scan(s) => scan::run(s),
     };
 
     // Display any errors

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -38,8 +38,7 @@ fn scan_network(network: &IpNetwork, port: u16) -> Result<(), TeleportError> {
         let socket = sa.to_socket_addrs().unwrap();
         for s in socket {
             if let Ok(ack) = ping(&s) {
-                println!("Teleporter detected on {sa}");
-                println!("{:?}", ack);
+                println!("Teleporter v{} detected on {sa}", ack.version.to_string());
             };
         }
     }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -47,7 +47,7 @@ fn scan_network(network: &IpNetwork, port: u16) -> Result<(), TeleportError> {
 }
 
 fn ping(ip_addr: &SocketAddr) -> Result<TeleportInitAck, TeleportError> {
-    let stream = TcpStream::connect_timeout(ip_addr, Duration::new(0, 50000))?;
+    let stream = TcpStream::connect_timeout(ip_addr, Duration::new(0, 5000000))?;
     query(stream)
 }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -38,7 +38,7 @@ fn scan_network(network: &IpNetwork, port: u16) -> Result<(), TeleportError> {
         let socket = sa.to_socket_addrs().unwrap();
         for s in socket {
             if let Ok(ack) = ping(&s) {
-                println!("Teleporter v{} detected on {sa}", ack.version.to_string());
+                println!("Teleporter v{} detected on {sa}", ack.version);
             };
         }
     }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,9 @@
 use crate::errors::TeleportError;
-use pnet_datalink::interfaces;
 use ipnetwork::IpNetwork;
+use pnet_datalink::interfaces;
+use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+
 use crate::ScanOpt;
 
 pub fn run(opt: ScanOpt) -> Result<(), TeleportError> {
@@ -14,11 +17,19 @@ pub fn run(opt: ScanOpt) -> Result<(), TeleportError> {
             }
             for v in &i.ips {
                 if v.is_ipv4() {
-                    println!("{:?}", i.ips);
+                    scan_network(&v, opt.port);
                 }
             }
         }
     }
 
     Ok(())
+}
+
+fn scan_network(network: &IpNetwork, port: u16) {
+    for i in network.iter() {
+        let sa = format!("{}:{port}", i);
+        let socket = sa.to_socket_addrs().unwrap();
+        println!("{socket:?}");
+    }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,0 +1,24 @@
+use crate::errors::TeleportError;
+use pnet_datalink::interfaces;
+use ipnetwork::IpNetwork;
+use crate::ScanOpt;
+
+pub fn run(opt: ScanOpt) -> Result<(), TeleportError> {
+    let ifs = interfaces();
+    let localv4 = IpNetwork::V4("127.0.0.1/8".parse().unwrap());
+
+    for i in ifs {
+        if !i.ips.is_empty() {
+            if i.ips.contains(&localv4) {
+                continue;
+            }
+            for v in &i.ips {
+                if v.is_ipv4() {
+                    println!("{:?}", i.ips);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/send.rs
+++ b/src/send.rs
@@ -272,7 +272,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         if num == 0 {
             println!(
                 "Server {}.{}.{}",
-                recv.version[0], recv.version[1], recv.version[2]
+                recv.version.major, recv.version.minor, recv.version.patch
             );
         }
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -270,7 +270,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         recv.deserialize(&packet.data)?;
 
         if num == 0 {
-            println!("Server {}", recv.version.to_string());
+            println!("Server {}", recv.version);
         }
 
         // Validate response
@@ -294,11 +294,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
                 continue;
             }
             TeleportStatus::WrongVersion => {
-                println!(
-                    "Version mismatch! Server: {} Us: {}",
-                    recv.version.to_string(),
-                    VERSION
-                );
+                println!("Version mismatch! Server: {} Us: {}", recv.version, VERSION);
                 break;
             }
             TeleportStatus::RequiresEncryption => {

--- a/src/send.rs
+++ b/src/send.rs
@@ -270,7 +270,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         recv.deserialize(&packet.data)?;
 
         if num == 0 {
-            println!("Server {}", recv.version.to_string(),);
+            println!("Server {}", recv.version.to_string());
         }
 
         // Validate response

--- a/src/send.rs
+++ b/src/send.rs
@@ -270,10 +270,7 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
         recv.deserialize(&packet.data)?;
 
         if num == 0 {
-            println!(
-                "Server {}.{}.{}",
-                recv.version.major, recv.version.minor, recv.version.patch
-            );
+            println!("Server {}", recv.version.to_string(),);
         }
 
         // Validate response
@@ -298,8 +295,9 @@ pub fn run(mut opt: SendOpt) -> Result<(), TeleportError> {
             }
             TeleportStatus::WrongVersion => {
                 println!(
-                    "Version mismatch! Server: {:?} Us: {}",
-                    recv.version, VERSION
+                    "Version mismatch! Server: {} Us: {}",
+                    recv.version.to_string(),
+                    VERSION
                 );
                 break;
             }

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -214,9 +214,17 @@ impl TeleportVersion {
         self.patch = buf.read_u16::<LittleEndian>()?;
         Ok(())
     }
+
+    pub fn to_string(&self) -> String {
+        format!("{}.{}.{}", self.major, self.minor, self.patch).to_owned()
+    }
+
+    pub fn is_compatible(&self, version: &Version) -> bool {
+        version.major == self.major as u64 && version.minor == self.minor as u64
+    }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct TeleportInit {
     pub version: TeleportVersion,
     pub features: u32,

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -24,6 +24,8 @@ pub enum TeleportAction {
     InitAck = 0x02,
     Ecdh = 0x04,
     EcdhAck = 0x08,
+    Scan = 0x10,
+    ScanAck = 0x20,
     Data = 0x40,
     Encrypted = 0x80,
 }

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -216,7 +216,7 @@ impl TeleportVersion {
     }
 
     pub fn to_string(&self) -> String {
-        format!("{}.{}.{}", self.major, self.minor, self.patch).to_owned()
+        format!("{}.{}.{}", self.major, self.minor, self.patch)
     }
 
     pub fn is_compatible(&self, version: &Version) -> bool {

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -3,6 +3,7 @@ use crate::errors::TeleportError;
 use crate::{PROTOCOL, VERSION};
 use byteorder::{LittleEndian, ReadBytesExt};
 use semver::Version;
+use std::fmt;
 use std::fs::File;
 use std::hash::Hasher;
 use std::io::{Read, Seek};
@@ -215,12 +216,14 @@ impl TeleportVersion {
         Ok(())
     }
 
-    pub fn to_string(&self) -> String {
-        format!("{}.{}.{}", self.major, self.minor, self.patch)
-    }
-
     pub fn is_compatible(&self, version: &Version) -> bool {
         version.major == self.major as u64 && version.minor == self.minor as u64
+    }
+}
+
+impl fmt::Display for TeleportVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
     }
 }
 

--- a/src/teleport.rs
+++ b/src/teleport.rs
@@ -24,8 +24,8 @@ pub enum TeleportAction {
     InitAck = 0x02,
     Ecdh = 0x04,
     EcdhAck = 0x08,
-    Scan = 0x10,
-    ScanAck = 0x20,
+    Ping = 0x10,
+    PingAck = 0x20,
     Data = 0x40,
     Encrypted = 0x80,
 }
@@ -157,6 +157,7 @@ pub enum TeleportFeatures {
     Overwrite = 0x04,
     Backup = 0x08,
     Rename = 0x10,
+    Ping = 0x20,
 }
 
 impl TeleportFeatures {


### PR DESCRIPTION
Add command to scan all interfaces with IPv4 subnets available for any remote teleporter servers listening on a specific port. This reports back the server version and IP address.
This PR also cleans up some protocol handling of `TeleportVersion`.